### PR TITLE
Error when initializing db with audit option disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ from kybra_simple_db import Database
 
 # Initialize storage and database
 storage = StableBTreeMap[str, str](memory_id=1, max_key_size=100, max_value_size=1000)  # Use a unique memory ID for each storage instance
-Database(storage, audit_enabled=True)
+Database.init(db_storage=storage)
 ```
 
 Read [Kybra's documentation](https://demergent-labs.github.io/kybra/stable_structures.html?highlight=StableBTreeMap) for more information regarding StableBTreeMap and memory IDs.
@@ -119,6 +119,8 @@ Then use the defined entities to store objects:
 
     '''
 ```
+
+For more usage examples, see the [tests](tests/src/tests).
 
 ## API Reference
 

--- a/kybra_simple_db/db_engine.py
+++ b/kybra_simple_db/db_engine.py
@@ -53,9 +53,9 @@ class Database:
             self._db_audit.insert("_min_id", "0")
             self._db_audit.insert("_max_id", "0")
 
-        logger.debug(
-            f"Audit database initialized with {len(list(self._db_audit.items()))} items"
-        )
+            logger.debug(
+                f"Audit database initialized with {len(list(self._db_audit.items()))} items"
+            )
 
         self._entity_types = {}
 

--- a/kybra_simple_db/db_engine.py
+++ b/kybra_simple_db/db_engine.py
@@ -58,7 +58,6 @@ class Database:
         )
 
         self._entity_types = {}
-        self._next_id: int = 1
 
     def clear(self):
         keys = list(self._db_storage.keys())
@@ -74,12 +73,6 @@ class Database:
 
         self._db_audit.insert("_min_id", "0")
         self._db_audit.insert("_max_id", "0")
-
-    def get_next_id(self) -> int:
-        """Get the next available ID and increment the counter"""
-        current_id = self._next_id
-        self._next_id += 1
-        return current_id
 
     def _audit(self, op: str, key: str, data: Any) -> None:
         if self._db_audit and self._audit_enabled:
@@ -209,10 +202,12 @@ class Database:
         Returns:
             A JSON string representation of the raw storage contents
         """
-        raw_data = self._db_storage._data
+        result = {}
+        for key in self._db_storage.keys():
+            result[key] = self._db_storage.get(key)
         if pretty:
-            return json.dumps(raw_data, indent=2)
-        return json.dumps(raw_data)
+            return json.dumps(result, indent=2)
+        return json.dumps(result)
 
     def get_audit(
         self, id_from: Optional[int] = None, id_to: Optional[int] = None

--- a/kybra_simple_db/entity.py
+++ b/kybra_simple_db/entity.py
@@ -87,11 +87,13 @@ class Entity:
             PermissionError: If TimestampedMixin is used and caller is not the owner
         """
 
+        type_name = self.__class__.__name__
+        db = self.__class__.db()
+
         if self._id is None:
-            self._id = str(self.db().get_next_id())
+            self._id = str(int(db.load("_system", "_id") or 0) + 1)
+            db.save("_system", "_id", str(int(self._id)))
         elif not self._loaded:
-            type_name = self.__class__.__name__
-            db = self.__class__.db()
             if db.load(type_name, self._id) is not None:
                 raise ValueError(f"Entity {self._type}@{self._id} already exists")
 
@@ -188,6 +190,7 @@ class Entity:
             List of entities
         """
         db = Database.get_instance()
+        db.register_entity_type(cls)
         instances = []
 
         # Get all keys from storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-kybra-simple-logging
+kybra-simple-logging==0.1.*

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -67,19 +67,32 @@ if [ "$TEST_RESULT" != '(0 : int)' ]; then
   exit 1
 fi
 
+echo "Getting database dump before upgrade..."
+BEFORE_UPGRADE=$(dfx canister call test dump_json)
+
 echo "Testing upgrade persistence check..."
 echo "Upgrading canister..."
 dfx deploy --mode=upgrade
+
+echo "Getting database dump after upgrade..."
+AFTER_UPGRADE=$(dfx canister call test dump_json)
+
+echo "Before: $BEFORE_UPGRADE"
+echo "After: $AFTER_UPGRADE"
+
+if [ "$BEFORE_UPGRADE" != "$AFTER_UPGRADE" ]; then
+  echo "ERROR: Database content changed after upgrade!"
+  exit 1
+fi
 
 TEST_ID="upgrade_after"
 TEST_RESULT=$(dfx canister call test run_test ${TEST_ID})
 if [ "$TEST_RESULT" != '(0 : int)' ]; then
   echo "Error: test_${TEST_ID}.run() function returned unexpected result: $TEST_RESULT"
-  dfx stop
   exit 1
 fi
 
-echo "Upgrade persistence test passed! Database content maintained across upgrade."
+echo "Upgrade persistence test passed! Database logic consistent across upgrade."
 
 echo "Stopping dfx..."
 dfx stop

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -52,4 +52,36 @@ for TEST_ID in "${TEST_IDS[@]}"; do
   dfx stop
 done
 
+echo "Testing specific upgrade persistence check..."
+echo "Starting dfx..."
+dfx start --clean --background
+
+echo "Deploying test canister..."
+dfx deploy
+
+TEST_ID="upgrade_before"
+TEST_RESULT=$(dfx canister call test run_test ${TEST_ID})
+if [ "$TEST_RESULT" != '(0 : int)' ]; then
+  echo "Error: test_${TEST_ID}.run() function returned unexpected result: $TEST_RESULT"
+  dfx stop
+  exit 1
+fi
+
+echo "Testing upgrade persistence check..."
+echo "Upgrading canister..."
+dfx deploy --mode=upgrade
+
+TEST_ID="upgrade_after"
+TEST_RESULT=$(dfx canister call test run_test ${TEST_ID})
+if [ "$TEST_RESULT" != '(0 : int)' ]; then
+  echo "Error: test_${TEST_ID}.run() function returned unexpected result: $TEST_RESULT"
+  dfx stop
+  exit 1
+fi
+
+echo "Upgrade persistence test passed! Database content maintained across upgrade."
+
+echo "Stopping dfx..."
+dfx stop
+
 echo "All done!"

--- a/tests/src/main.py
+++ b/tests/src/main.py
@@ -32,4 +32,4 @@ def run_test(module_name: str) -> int:
 
 @query
 def dump_json() -> str:
-    return Database.get_instance().dump_json()
+    return Database.get_instance().raw_dump_json()

--- a/tests/src/main.py
+++ b/tests/src/main.py
@@ -10,6 +10,8 @@ from tests import (
     test_mixins,
     test_properties,
     test_relationships,
+    test_upgrade_after,
+    test_upgrade_before,
 )
 
 db_storage = StableBTreeMap[str, str](

--- a/tests/src/main.py
+++ b/tests/src/main.py
@@ -22,13 +22,12 @@ db_audit = StableBTreeMap[str, str](
 Database.init(audit_enabled=True, db_storage=db_storage, db_audit=db_audit)
 
 
-@query
-def greet() -> str:
-    ic.print("Hello!")
-    return "Hello!"
-
-
 @update
 def run_test(module_name: str) -> int:
     ic.print(f"Running test_{module_name}...")
     return globals()[f"test_{module_name}"].run()
+
+
+@query
+def dump_json() -> str:
+    return Database.get_instance().dump_json()

--- a/tests/src/tester.py
+++ b/tests/src/tester.py
@@ -30,6 +30,15 @@ class Tester:
                 logger.error(f"{test.__name__} failed: {e}")  # Red for fail
                 logger.error(traceback.format_exc())
                 failed += 1
+            finally:
+                # Call tearDown if it exists, regardless of test result
+                if hasattr(self.test_instance, "tearDown"):
+                    try:
+                        self.test_instance.tearDown()
+                    except Exception as e:
+                        logger.error(f"tearDown failed: {e}")
+                        logger.error(traceback.format_exc())
+                        # Don't increment failed count, as this is not a test failure
         logger.info(
             f"\033[91m{failed} tests failed\033[0m"
             if failed > 0

--- a/tests/src/tests/test_audit.py
+++ b/tests/src/tests/test_audit.py
@@ -91,6 +91,41 @@ class TestAudit:
         assert "age" in entity_data
         assert entity_data["age"] == 30
 
+    def test_no_audit_when_disabled(self):
+        """Test that no audit records are created when audit_enabled is False."""
+        # Create a new database instance with audit_enabled=False
+        Database._instance = None  # Reset the singleton
+        db_no_audit = Database.init(audit_enabled=False)
+        
+        # Clear any existing data
+        db_no_audit.clear()
+        
+        # Perform operations that would normally create audit records
+        person_data = {
+            "name": "Alice",
+            "age": 25,
+            "creator": "system",
+            "owner": "system",
+            "updater": "system",
+        }
+        
+        # Save operation
+        db_no_audit.save("Person", "1", person_data)
+        
+        # Update operation
+        db_no_audit.update("Person", "1", "age", 26)
+        
+        # Delete operation
+        db_no_audit.delete("Person", "1")
+        
+        # Verify that no audit records were created
+        # The _db_audit attribute should be None when audit_enabled=False
+        assert db_no_audit._db_audit is None
+        
+        # Reset the singleton for other tests
+        Database._instance = None
+        self.db = Database.get_instance()  # Re-initialize with default settings for other tests
+
 
 def run():
     tester = Tester(TestAudit)

--- a/tests/src/tests/test_audit.py
+++ b/tests/src/tests/test_audit.py
@@ -13,6 +13,10 @@ class TestAudit:
         self.db = Database.get_instance()
         self.db.clear()
 
+    def tearDown(self):
+        """Clean up after each test by resetting the database singleton."""
+        Database._instance = None
+
     def test_audit_initialization(self):
         """Test if the audit database is initialized correctly."""
         assert self.db._db_audit is not None
@@ -96,10 +100,10 @@ class TestAudit:
         # Create a new database instance with audit_enabled=False
         Database._instance = None  # Reset the singleton
         db_no_audit = Database.init(audit_enabled=False)
-        
+
         # Clear any existing data
         db_no_audit.clear()
-        
+
         # Perform operations that would normally create audit records
         person_data = {
             "name": "Alice",
@@ -108,23 +112,19 @@ class TestAudit:
             "owner": "system",
             "updater": "system",
         }
-        
+
         # Save operation
         db_no_audit.save("Person", "1", person_data)
-        
+
         # Update operation
         db_no_audit.update("Person", "1", "age", 26)
-        
+
         # Delete operation
         db_no_audit.delete("Person", "1")
-        
+
         # Verify that no audit records were created
         # The _db_audit attribute should be None when audit_enabled=False
         assert db_no_audit._db_audit is None
-        
-        # Reset the singleton for other tests
-        Database._instance = None
-        self.db = Database.get_instance()  # Re-initialize with default settings for other tests
 
 
 def run():

--- a/tests/src/tests/test_entity.py
+++ b/tests/src/tests/test_entity.py
@@ -17,8 +17,7 @@ class Department(Entity):
 class TestEntity:
     def setUp(self):
         """Reset Entity class variables before each test."""
-        Entity._context = set()
-        Database._instance = Database(MemoryStorage())
+        Database.get_instance().clear()
 
     def test_entity_creation_and_save(self):
         """Test creating and saving an entity."""
@@ -99,6 +98,7 @@ class TestEntity:
         persons = Person.instances()
 
         # Check that we have the correct number of instances
+        print("len(persons)", len(persons))
         assert len(persons) == 2
 
         # Check that the instances match the saved persons
@@ -117,6 +117,7 @@ class TestEntity:
         departments = Department.instances()
 
         # Check that we have the correct number of instances for each type
+        print("len(persons)", len(persons))
         assert len(persons) == 1
         assert len(departments) == 1
 

--- a/tests/src/tests/test_example_1.py
+++ b/tests/src/tests/test_example_1.py
@@ -68,4 +68,5 @@ def run():
 
 
 if __name__ == "__main__":
+    Database.get_instance().clear()
     exit(run())

--- a/tests/src/tests/test_example_2.py
+++ b/tests/src/tests/test_example_2.py
@@ -69,4 +69,5 @@ def run():
 
 
 if __name__ == "__main__":
+    ksdb.Database.get_instance().clear()
     exit(run())

--- a/tests/src/tests/test_mixins.py
+++ b/tests/src/tests/test_mixins.py
@@ -16,8 +16,7 @@ class TestEntity(Entity, TimestampedMixin):
 class TestMixins:
     def setUp(self):
         """Reset Entity class variables before each test."""
-        Entity._context = set()
-        Database._instance = Database(MemoryStorage())
+        Database.get_instance().clear()
 
     def test_timestamped_mixin(self):
         """Test that TimestampedMixin adds timestamp and ownership functionality."""

--- a/tests/src/tests/test_properties.py
+++ b/tests/src/tests/test_properties.py
@@ -136,6 +136,7 @@ class TestProperties:
 
 
 def run():
+    Database.get_instance().clear()
     tester = Tester(TestProperties)
     return tester.run_tests()
 

--- a/tests/src/tests/test_relationships.py
+++ b/tests/src/tests/test_relationships.py
@@ -58,9 +58,7 @@ class TestRelationships:
 
     def setUp(self):
         """Set up test database."""
-        db_storage = MemoryStorage()
-        self.db = Database(db_storage)
-        Database._instance = self.db
+        Database.get_instance().clear()
 
     def test_one_to_one(self):
         """Test one-to-one relationships."""

--- a/tests/src/tests/test_upgrade_after.py
+++ b/tests/src/tests/test_upgrade_after.py
@@ -21,6 +21,14 @@ class Person(Entity):
 def run():
     assert len(Person.instances()) == 1
 
+    bob = Person(name="Bob")
+    assert bob.name == "Bob"
+
+    assert len(Person.instances()) == 2
+
+    assert Person["1"].name == "Alice"
+    assert Person["2"].name == "Bob"
+
     return 0
 
 

--- a/tests/src/tests/test_upgrade_after.py
+++ b/tests/src/tests/test_upgrade_after.py
@@ -1,0 +1,29 @@
+"""Simple example script showing basic usage of kybra_simple_db with:
+
+- Creation modification and deletion of objects.
+- Properties and relationships."""
+
+from kybra_simple_logging import get_logger
+
+from kybra_simple_db import (
+    Database,
+    Entity,
+    String,
+)
+
+logger = get_logger(__name__)
+
+
+class Person(Entity):
+    name = String(min_length=2, max_length=50)
+
+
+def run():
+    assert len(Person.instances()) == 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    Database.get_instance().clear()
+    exit(run())

--- a/tests/src/tests/test_upgrade_before.py
+++ b/tests/src/tests/test_upgrade_before.py
@@ -1,0 +1,33 @@
+"""Simple example script showing basic usage of kybra_simple_db with:
+
+- Creation modification and deletion of objects.
+- Properties and relationships."""
+
+from kybra_simple_logging import get_logger
+
+from kybra_simple_db import (
+    Database,
+    Entity,
+    String,
+)
+
+logger = get_logger(__name__)
+
+
+class Person(Entity):
+    name = String(min_length=2, max_length=50)
+
+
+def run():
+    # Create and save a person
+    john = Person(name="John")
+    assert john.name == "John"
+
+    assert len(Person.instances()) == 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    Database.get_instance().clear()
+    exit(run())

--- a/tests/src/tests/test_upgrade_before.py
+++ b/tests/src/tests/test_upgrade_before.py
@@ -20,10 +20,11 @@ class Person(Entity):
 
 def run():
     # Create and save a person
-    john = Person(name="John")
-    assert john.name == "John"
+    alice = Person(name="Alice")
+    assert alice.name == "Alice"
 
     assert len(Person.instances()) == 1
+    assert Person["1"].name == "Alice"
 
     return 0
 


### PR DESCRIPTION
`Database.init(..)` returns the following error when `audit_enabled` is `False` or `None`:

```
Caused by: The replica returned a rejection error: reject code CanisterError, reject message Error from Canister wxfhb-tqaaa-aaaah-aq2qq-cai: Canister called `ic0.trap` with message: 'AttributeError: 'NoneType' object has no attribute 'items''
Canister Backtrace:
ic_cdk::api::trap
<core::result::Result<T,rustpython_vm::object::core::PyRef<rustpython_vm::exceptions::types::PyBaseException>> as realm_backend::UnwrapOrTrapWithVm<T>>::unwrap_or_trap
realm_backend::post_upgrade
realm_backend::__canister_method_post_upgrade::{{closure}}
ic_cdk::futures::spawn
canister_post_upgrade
canister_post_upgrade.command_export
```